### PR TITLE
Use ovirt/upload-rpms-action to upload RPMs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,12 +82,7 @@ jobs:
       run: |
         .automation/build-rpm.sh $ARTIFACTS_DIR
 
-    - name: Create DNF repository
-      run: |
-        createrepo_c $ARTIFACTS_DIR
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+    - name: Upload RPMs
+      uses: ovirt/upload-rpms-action@v2
       with:
-        name: rpm-${{ matrix.shortcut }}
-        path: ${{ env.ARTIFACTS_DIR}}
+        directory: ${{ env.ARTIFACTS_DIR }}


### PR DESCRIPTION
Use ovirt/upload-rpms-action to upload RPMs created by the build.

Signed-off-by: Martin Perina <mperina@redhat.com>
