### PR TITLE
Require maven package due to old xmvn in COPR

### DIFF
--- a/ovirt-engine-extension-aaa-misc.spec.in
+++ b/ovirt-engine-extension-aaa-misc.spec.in
@@ -34,6 +34,9 @@ BuildRequires:	mvn(javax.servlet:javax.servlet-api)
 BuildRequires:	mvn(org.ovirt.engine.api:ovirt-engine-extensions-api)
 BuildRequires:	mvn(org.slf4j:slf4j-api)
 
+# Required because of old xmvn version in COPR
+BuildRequires: maven
+
 
 Requires:	java-11-openjdk-headless >= 1:11.0.0
 Requires:	javapackages-filesystem


### PR DESCRIPTION
Signed-off-by: Martin Perina <mperina@redhat.com>
