### PR TITLE
Handle situation when empty groups not come from the keycloak

### DIFF
--- a/src/main/java/org/ovirt/engine/extension/aaa/misc/QueryExecutor.java
+++ b/src/main/java/org/ovirt/engine/extension/aaa/misc/QueryExecutor.java
@@ -93,8 +93,14 @@ public class QueryExecutor {
     }
 
     public Collection<ExtMap> buildPrincipalRecordGroups(Map<String, String> headers, String groupsArg) {
+        List<String> groupNames;
+        if (headers.containsKey(groupsArg)) {
+            groupNames = Arrays.asList(headers.get(groupsArg).split(","));
+        } else {
+            return Collections.emptyList();
+        }
+
         LinkedList<ExtMap> groups = new LinkedList<>();
-        List<String> groupNames = Arrays.asList(headers.get(groupsArg).split(","));
         for (String groupName : groupNames) {
             groupName = groupName.replaceFirst("^/", "");
             ExtMap group = new ExtMap();


### PR DESCRIPTION
Before the keycloak v22 it sends empty array as group claim when user not a member of any group. After v22 it not put this claim at all.
Look discussion: https://github.com/keycloak/keycloak/issues/22340