### PR TITLE
Mark current dir as safe for git in build-srpm.sh

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -xe
 
+# From git 2.35.2 we need to mark temporary directory, where the project is cloned to, as safe, otherwise
+# git commands won't work because of the fix for CVE-2022-24765
+git config --global --add safe.directory "$(pwd)"
+
 # git hash of current commit should be passed as the 1st paraameter
 if [ "${GITHUB_SHA}" == "" ]; then
   GIT_HASH=$(git rev-list HEAD | wc -l)


### PR DESCRIPTION
Mark current directory as safe for git operation to be able to create
RPM release properly.

Signed-off-by: Martin Perina <mperina@redhat.com>
